### PR TITLE
Adapt builder to syn 1.0 changes

### DIFF
--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -16,6 +16,6 @@ path = "tests/progress.rs"
 trybuild = "1.0"
 
 [dependencies]
-syn = { version = "0.15", features = ["extra-traits"] }
-quote = "0.6"
-proc-macro2 = "0.4"
+syn = { version = "1.0", features = ["extra-traits"] }
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -162,7 +162,7 @@ fn extend_method(f: &syn::Field) -> Option<(bool, proc_macro2::TokenStream)> {
     let meta = match g.parse_meta() {
         Ok(syn::Meta::List(mut nvs)) => {
             // list here is .. in #[builder(..)]
-            assert_eq!(nvs.ident, "builder");
+            assert!(nvs.path.is_ident("builder"));
             if nvs.nested.len() != 1 {
                 return mk_err(nvs);
             }
@@ -170,7 +170,7 @@ fn extend_method(f: &syn::Field) -> Option<(bool, proc_macro2::TokenStream)> {
             // nvs.nested[0] here is (hopefully): each = "foo"
             match nvs.nested.pop().unwrap().into_value() {
                 syn::NestedMeta::Meta(syn::Meta::NameValue(nv)) => {
-                    if nv.ident != "each" {
+                    if !nv.path.is_ident("each") {
                         return mk_err(nvs);
                     }
                     nv
@@ -219,7 +219,7 @@ fn ty_inner_type<'a>(wrapper: &str, ty: &'a syn::Type) -> Option<&'a syn::Type> 
             }
 
             let inner_ty = inner_ty.args.first().unwrap();
-            if let syn::GenericArgument::Type(ref t) = inner_ty.value() {
+            if let syn::GenericArgument::Type(ref t) = inner_ty {
                 return Some(t);
             }
         }


### PR DESCRIPTION
Not sure if you intend this code to be kept up to date, but the changes are pretty minor.

Fixes compile errors of two flavors, e.g.
```
error[E0609]: no field `ident` on type `syn::attr::MetaList`
   --> builder/src/lib.rs:165:28
    |
165 |             assert_eq!(nvs.ident, "builder");
    |                            ^^^^^ unknown field
    |
    = note: available fields are: `path`, `paren_token`, `nested`
```
```
error[E0599]: no method named `value` found for type `&syn::path::GenericArgument` in the current scope
   --> builder/src/lib.rs:222:65
    |
222 |             if let syn::GenericArgument::Type(ref t) = inner_ty.value() {
    |                                                                 ^^^^^ method not found in `&syn::path::GenericArgument`
```

